### PR TITLE
Add support for optional compression in CLBGFile creation and extraction

### DIFF
--- a/test/clbgFile.test.ts
+++ b/test/clbgFile.test.ts
@@ -104,6 +104,31 @@ describe("CLBGFile", () => {
       mkdirSync(OUTPUT_DIRECTORY);
     });
 
+    test("should create a valid clbg file without compression", async () => {
+      const clbgFile = await CLBGFile.create({
+        coverFile: COVER_FILE,
+        disableCompression: true,
+        metadata: METADATA,
+        overwrite: true,
+        sourceDirectory: INPUT_DIRECTORY,
+        targetFile: TARGET_FILE,
+      });
+
+      const createdFile = await CLBGFile.fromFile(TARGET_FILE);
+      expect(createdFile.header).toEqual(clbgFile.header);
+      expect(createdFile.metadata).toEqual(clbgFile.metadata);
+      expect(createdFile.cover).toEqual(clbgFile.cover);
+
+      await createdFile.extractGame(OUTPUT_DIRECTORY);
+
+      expect(
+        readFileSync(join(OUTPUT_DIRECTORY, "test_text.txt"), "utf-8")
+      ).toEqual(TXT_FILE);
+
+      rmSync(OUTPUT_DIRECTORY, { recursive: true });
+      mkdirSync(OUTPUT_DIRECTORY);
+    });
+
     test("should overwrite an existing target file if overwrite is true", async () => {
       await CLBGFile.create({
         coverFile: COVER_FILE,


### PR DESCRIPTION
This pull request introduces the ability to disable compression when creating and extracting CLBG files. It includes changes to the `CLBGFile` class and adds a new test case to ensure the functionality works correctly.

### New Features:
* [`src/models/CLBGFile.ts`](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1R31): Added a `disableCompression` option to the `CreateOptions` interface to allow disabling compression when creating a CLBG file.
* [`src/models/CLBGFile.ts`](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1R123-R152): Implemented the `isCompressed` method to check if a file is compressed by reading its magic numbers.
* [`src/models/CLBGFile.ts`](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1R161-R162): Modified the `extractArchiveToDirectory` method to handle both compressed and uncompressed files based on the `isCompressed` method's result. [[1]](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1R161-R162) [[2]](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1R175-R179)
* [`src/models/CLBGFile.ts`](diffhunk://#diff-f0a12bbad9422f274e272e39ccfbd3836004428c39879b4d26f509823b4933e1L295-R347): Updated the method for writing a CLBG file to use the appropriate compression stream based on the `disableCompression` option.

### Tests:
* [`test/clbgFile.test.ts`](diffhunk://#diff-14e7a7d552bb6824c7cd51e3b5d0a22e623d7899ee28d9e94b5f7d46d64b3931R107-R131): Added a test case to verify that a CLBG file can be created and extracted without compression when the `disableCompression` option is set to true.